### PR TITLE
Provide basic facilities for upgrading SKIRT 9 ski files

### DIFF
--- a/simulation/skifile.py
+++ b/simulation/skifile.py
@@ -43,12 +43,12 @@ class SkiFile:
 
     ## The constructor loads the contents of the specified ski file into a new SkiFile instance.
     # The file path is interpreted as described for the pts.utils.absPath() function.
-    # The filename of the ski file \em must end with ".ski" or with "_parameters.xml".
+    # The filename extension of the ski file \em must be ".ski" or ".xml".
     #
     def __init__(self, skiFilePath):
         # get the absolute path and verify the file name
         self._path = ut.absPath(skiFilePath)
-        if not self._path.name.lower().endswith((".ski", "_parameters.xml")):
+        if self._path.suffix.lower() not in (".ski", ".xml"):
             raise ValueError("Invalid filename extension for ski file")
 
         # load the XML tree from the ski file (remove blank text to avoid confusing the pretty printer when saving)
@@ -60,13 +60,13 @@ class SkiFile:
 
     ## This function saves the (possibly updated) contents of the SkiFile instance into the specified file.
     # The file path is interpreted as described for the pts.utils.absPath() function.
-    # The name of the file \em must end with ".ski" or with "_parameters.xml".
+    # The filename extension of the file \em must be ".ski" or ".xml".
     # Saving to and thus replacing the ski file from which this
     # SkiFile instance was originally constructed is allowed, but often not the intention.
     def saveTo(self, saveFilePath):
         # get the absolute path and verify the file name
         path = ut.absPath(saveFilePath)
-        if not path.name.lower().endswith(".ski"):
+        if self._path.suffix.lower() not in (".ski", ".xml"):
             raise ValueError("Invalid filename extension for ski file")
 
         # update the producer and time attributes on the root element

--- a/skiupgrade/__init__.py
+++ b/skiupgrade/__init__.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+# -*- coding: utf8 -*-
+# *****************************************************************
+# **       PTS -- Python Toolkit for working with SKIRT          **
+# **       © Astronomical Observatory, Ghent University          **
+# *****************************************************************
+
+# -----------------------------------------------------------------
+#  Package initialization file
+# -----------------------------------------------------------------
+
+## \package pts.skiupgrade Facilities for upgrading SKIRT parameter files
+#
+# This package includes facilities for upgrading SKIRT parameter files (\em ski files)
+# between versions of SKIRT 9.
+#
+
+from .skiupgrade import upgradeSkiFile

--- a/skiupgrade/do/__init__.py
+++ b/skiupgrade/do/__init__.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+# -*- coding: utf8 -*-
+# *****************************************************************
+# **       PTS -- Python Toolkit for working with SKIRT          **
+# **       © Astronomical Observatory, Ghent University          **
+# *****************************************************************
+
+# -----------------------------------------------------------------
+#  Package initialization file
+# -----------------------------------------------------------------
+
+## \package pts.skiupgrade.do Commands for upgrading SKIRT parameter files
+#
+# The Python scripts residing in the do sub-directory of this package implement commands
+# to assist with upgrading SKIRT parameter files (\em ski files) between versions of SKIRT 9.

--- a/skiupgrade/do/test_upgrade_ski_files.py
+++ b/skiupgrade/do/test_upgrade_ski_files.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# -*- coding: utf8 -*-
+# *****************************************************************
+# **       PTS -- Python Toolkit for working with SKIRT          **
+# **       © Astronomical Observatory, Ghent University          **
+# *****************************************************************
+
+## \package pts.skiupgrade.do.test_upgrade_ski_files Test upgrading ski files to the latest version of SKIRT
+#
+# This script upgrades all SKIRT 9 ski files in a given directory to be appropriate for the latest version of SKIRT 9
+# without touching the original files. Instead the upgraded versions are given a new name. This is useful when testing
+# the upgrade procedure for a newly updated SKIRT version.
+#
+# Specifically, the script iterates over all files in the directory with the .ski filename extension and performs
+# as follows for each:
+# - if the file is not a SKIRT parameter file, or it is intended for a SKIRT version before version 9, a warning
+#   is issued and the file is otherwise ignored.
+# - if the file is a SKIRT 9 parameter file and it is up to date with the latest version of SKIRT 9, an informational
+#   message is issued and the file is otherwise ignored.
+# - if the file is a SKIRT 9 parameter file that needs upgrading, the version upgraded to the latest version of SKIRT 9
+#   is placed in a file with the same name as the original file extended with the string "_upgraded".
+#
+# The script takes a single positional string argument specifying the path to the directory containing the ski files to
+# be upgraded, or "." (a single period) for the current directory.
+#
+# See the pts.skiupgrade.skiupgrade module for more information on the ski file upgrade process.
+#
+
+# -----------------------------------------------------------------
+
+def do( skiDirPath : (str,"directory containing the ski files to be upgraded"),
+        ) -> "upgrade ski files in a given directory to the latest version of SKIRT 9":
+
+    import pts.skiupgrade
+    import pts.utils as ut
+
+    for skipath in ut.absPath(skiDirPath).glob("*.ski"):
+        pts.skiupgrade.upgradeSkiFile(skipath, backup=False, replace=False)
+
+# -----------------------------------------------------------------

--- a/skiupgrade/do/test_upgrade_ski_files.py
+++ b/skiupgrade/do/test_upgrade_ski_files.py
@@ -18,7 +18,7 @@
 # - if the file is a SKIRT 9 parameter file and it is up to date with the latest version of SKIRT 9, an informational
 #   message is issued and the file is otherwise ignored.
 # - if the file is a SKIRT 9 parameter file that needs upgrading, the version upgraded to the latest version of SKIRT 9
-#   is placed in a file with the same name as the original file extended with the string "_upgraded".
+#   is placed in a file with a name similar to the original including the string "upgraded".
 #
 # The script takes a single positional string argument specifying the path to the directory containing the ski files to
 # be upgraded, or "." (a single period) for the current directory.
@@ -34,7 +34,7 @@ def do( skiDirPath : (str,"directory containing the ski files to be upgraded"),
     import pts.skiupgrade
     import pts.utils as ut
 
-    for skipath in ut.absPath(skiDirPath).glob("*.ski"):
+    for skipath in sorted(ut.absPath(skiDirPath).glob("*.ski")):
         pts.skiupgrade.upgradeSkiFile(skipath, backup=False, replace=False)
 
 # -----------------------------------------------------------------

--- a/skiupgrade/do/test_upgrade_ski_files.py
+++ b/skiupgrade/do/test_upgrade_ski_files.py
@@ -13,12 +13,13 @@
 #
 # Specifically, the script iterates over all files in the directory with the .ski filename extension and performs
 # as follows for each:
-# - if the file is not a SKIRT parameter file, or it is intended for a SKIRT version before version 9, a warning
-#   is issued and the file is otherwise ignored.
+# - if the file is not a SKIRT parameter file, or it is intended for a SKIRT version before version 9, an error
+#   message is logged and the file is otherwise ignored.
 # - if the file is a SKIRT 9 parameter file and it is up to date with the latest version of SKIRT 9, an informational
-#   message is issued and the file is otherwise ignored.
+#   message is logged and the file is otherwise ignored.
 # - if the file is a SKIRT 9 parameter file that needs upgrading, the version upgraded to the latest version of SKIRT 9
-#   is placed in a file with a name similar to the original including the string "upgraded".
+#   is placed in a file with a name similar to the original including the string "upgraded", and a warning message
+#   is logged.
 #
 # The script takes a single positional string argument specifying the path to the directory containing the ski files to
 # be upgraded, or "." (a single period) for the current directory.

--- a/skiupgrade/do/upgrade_functional_tests.py
+++ b/skiupgrade/do/upgrade_functional_tests.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# -*- coding: utf8 -*-
+# *****************************************************************
+# **       PTS -- Python Toolkit for working with SKIRT          **
+# **       © Astronomical Observatory, Ghent University          **
+# *****************************************************************
+
+## \package pts.skiupgrade.do.upgrade_functional_tests Upgrade ski files for all or a subsuite of functional tests
+#
+# This script upgrades the ski files for a selection of the standard functional test cases for SKIRT 9.
+# The test case definitions are expected to reside in the \c SKIRT/Functional9 directory hierarchy.
+#
+# The script takes a single positional string argument, which can be one of the following:
+#  - "." (a single period): upgrade all test cases in the standard suite.
+#  - "testcase" (the name of a test case directory): upgrade all test cases with that name.
+#  - "subsuite" (the name of an intermediate directory in the hierarchy): upgrade the test cases in all sub-suites
+#    with that name.
+#  - "parentsubsuite/testcase" or "parentsubsuite/subsuite": upgrade the indicated test case(s) or sub-suite(s)
+#    that reside immediately inside the indicated parent sub-suite; this can disambiguate items with the same name.
+#
+# For each of the selected test cases, the script performs as follows:
+# - if the ski file is up to date with the latest version of SKIRT 9, an informational message is issued and the
+#   file is otherwise ignored.
+# - if the ski file needs upgrading, it is first copied to a backup version with a filename including a time stamp,
+#   and it is then replaced by a version upgraded to the latest version of SKIRT 9.
+#
+# See the pts.test.functional module for more information about test cases and test (sub-)suites.
+# See the pts.skiupgrade.skiupgrade module for more information on the ski file upgrade process.
+#
+
+# -----------------------------------------------------------------
+
+def do( subSuite : (str,"name of sub-suite or test case to be performed or '.' to perform all"),
+        ) -> "upgrade ski files for functional tests to the latest version of SKIRT 9":
+
+    import pts.skiupgrade
+    import pts.test
+
+    for skipath in pts.test.SkirtTestSuite(subSuite=subSuite).skiPaths():
+        pts.skiupgrade.upgradeSkiFile(skipath)
+
+# -----------------------------------------------------------------

--- a/skiupgrade/do/upgrade_functional_tests.py
+++ b/skiupgrade/do/upgrade_functional_tests.py
@@ -19,10 +19,10 @@
 #    that reside immediately inside the indicated parent sub-suite; this can disambiguate items with the same name.
 #
 # For each of the selected test cases, the script performs as follows:
-# - if the ski file is up to date with the latest version of SKIRT 9, an informational message is issued and the
+# - if the ski file is up to date with the latest version of SKIRT 9, an informational message is logged and the
 #   file is otherwise ignored.
 # - if the ski file needs upgrading, it is first copied to a backup version with a filename including a time stamp,
-#   and it is then replaced by a version upgraded to the latest version of SKIRT 9.
+#   it is then replaced by a version upgraded to the latest version of SKIRT 9, and a warning message is logged.
 #
 # See the pts.test.functional module for more information about test cases and test (sub-)suites.
 # See the pts.skiupgrade.skiupgrade module for more information on the ski file upgrade process.

--- a/skiupgrade/do/upgrade_ski_files.py
+++ b/skiupgrade/do/upgrade_ski_files.py
@@ -31,7 +31,7 @@ def do( skiDirPath : (str,"directory containing the ski files to be upgraded"),
     import pts.skiupgrade
     import pts.utils as ut
 
-    for skipath in ut.absPath(skiDirPath).glob("*.ski"):
+    for skipath in sorted(ut.absPath(skiDirPath).glob("*.ski")):
         pts.skiupgrade.upgradeSkiFile(skipath)
 
 # -----------------------------------------------------------------

--- a/skiupgrade/do/upgrade_ski_files.py
+++ b/skiupgrade/do/upgrade_ski_files.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+# -*- coding: utf8 -*-
+# *****************************************************************
+# **       PTS -- Python Toolkit for working with SKIRT          **
+# **       © Astronomical Observatory, Ghent University          **
+# *****************************************************************
+
+## \package pts.skiupgrade.do.upgrade_ski_files Upgrade ski files in a given directory to the latest version of SKIRT
+#
+# This script upgrades all SKIRT 9 ski files in a given directory to be appropriate for the latest version of SKIRT 9.
+# Specifically, the script iterates over all files in the directory with the .ski filename extension and performs
+# as follows for each:
+# - if the file is not a SKIRT parameter file, or it is intended for a SKIRT version before version 9, a warning
+#   is issued and the file is otherwise ignored.
+# - if the file is a SKIRT 9 parameter file and it is up to date with the latest version of SKIRT 9, an informational
+#   message is issued and the file is otherwise ignored.
+# - if the file is a SKIRT 9 parameter file that needs upgrading, it is first copied to a backup version with a
+#   filename including a time stamp, and it is then replaced by a version upgraded to the latest version of SKIRT 9.
+#
+# The script takes a single positional string argument specifying the path to the directory containing the ski files to
+# be upgraded, or "." (a single period) for the current directory.
+#
+# See the pts.skiupgrade.skiupgrade module for more information on the ski file upgrade process.
+#
+
+# -----------------------------------------------------------------
+
+def do( skiDirPath : (str,"directory containing the ski files to be upgraded"),
+        ) -> "upgrade ski files in a given directory to the latest version of SKIRT 9":
+
+    import pts.skiupgrade
+    import pts.utils as ut
+
+    for skipath in ut.absPath(skiDirPath).glob("*.ski"):
+        pts.skiupgrade.upgradeSkiFile(skipath)
+
+# -----------------------------------------------------------------

--- a/skiupgrade/do/upgrade_ski_files.py
+++ b/skiupgrade/do/upgrade_ski_files.py
@@ -10,12 +10,13 @@
 # This script upgrades all SKIRT 9 ski files in a given directory to be appropriate for the latest version of SKIRT 9.
 # Specifically, the script iterates over all files in the directory with the .ski filename extension and performs
 # as follows for each:
-# - if the file is not a SKIRT parameter file, or it is intended for a SKIRT version before version 9, a warning
-#   is issued and the file is otherwise ignored.
+# - if the file is not a SKIRT parameter file, or it is intended for a SKIRT version before version 9, an error
+#   message is logged and the file is otherwise ignored.
 # - if the file is a SKIRT 9 parameter file and it is up to date with the latest version of SKIRT 9, an informational
-#   message is issued and the file is otherwise ignored.
+#   message is logged and the file is otherwise ignored.
 # - if the file is a SKIRT 9 parameter file that needs upgrading, it is first copied to a backup version with a
-#   filename including a time stamp, and it is then replaced by a version upgraded to the latest version of SKIRT 9.
+#   filename including a time stamp, it is then replaced by a version upgraded to the latest version of SKIRT 9,
+#   and a warning message is logged.
 #
 # The script takes a single positional string argument specifying the path to the directory containing the ski files to
 # be upgraded, or "." (a single period) for the current directory.

--- a/skiupgrade/skiupgrade.py
+++ b/skiupgrade/skiupgrade.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+# -*- coding: utf8 -*-
+# *****************************************************************
+# **       PTS -- Python Toolkit for working with SKIRT          **
+# **       © Astronomical Observatory, Ghent University          **
+# *****************************************************************
+
+## \package pts.skiupgrade.skiupgrade Contains the upgradeSkiFile function for upgrading SKIRT parameter files
+#
+# The upgradeSkiFile function in this module allows upgrading SKIRT parameter files (\em ski files)
+# between versions of SKIRT 9.
+
+# -----------------------------------------------------------------
+
+import logging
+import pts.simulation as sm
+import pts.utils as ut
+
+# -----------------------------------------------------------------
+
+## This function
+# Specifically, the script iterates over all files with the .ski filename extension and performs as follows for each:
+# - if the file is not a SKIRT parameter file, or it is intended for a SKIRT version before version 9, a warning
+#   is issued and the file is otherwise ignored.
+# - if the file is a SKIRT 9 parameter file and it is up to date with the latest version of SKIRT 9, a informational
+#   message is issued and the file is otherwise ignored.
+# - if the file is a SKIRT 9 parameter file that needs upgrading, it is first copied to a backup version with a
+#   filename including a time stamp, and it is then replaced by a version upgraded to the latest version of SKIRT 9.
+
+def upgradeSkiFile(inpath, *, backup=True, replace=True):
+    inpath = ut.absPath(inpath)
+    logging.info("Processing ski file {}".format(inpath))
+
+    #outpath = inpath if replace else inpath.with_name(inpath.stem+"_upgraded.ski")
+
+# -----------------------------------------------------------------

--- a/skiupgrade/skiupgrade.py
+++ b/skiupgrade/skiupgrade.py
@@ -18,19 +18,53 @@ import pts.utils as ut
 
 # -----------------------------------------------------------------
 
-## This function
-# Specifically, the script iterates over all files with the .ski filename extension and performs as follows for each:
-# - if the file is not a SKIRT parameter file, or it is intended for a SKIRT version before version 9, a warning
-#   is issued and the file is otherwise ignored.
-# - if the file is a SKIRT 9 parameter file and it is up to date with the latest version of SKIRT 9, a informational
-#   message is issued and the file is otherwise ignored.
-# - if the file is a SKIRT 9 parameter file that needs upgrading, it is first copied to a backup version with a
-#   filename including a time stamp, and it is then replaced by a version upgraded to the latest version of SKIRT 9.
-
+## This function upgrades the specified SKIRT 9 parameter file (\em ski file) so that it becomes appropriate for the
+# latest SKIRT 9 version. The upgrade process supports all ski files created by the SKIRT project version 9 tools
+# (including the SKIRT command line Q&A and the graphical MakeUp wizard) since SKIRT 9 was publicly released.
+# Ski files created for older SKIRT versions (such as SKIRT 7 and 8) cannot be upgraded to SKIRT 9 automatically.
+#
+# The function accepts three arguments:
+# - inpath: the absolute or relative path to the ski file to be handled; the filename extension should be ".ski"
+# - backup: if the input ski file needs upgrading and \em backup is True (the default), a copy of the input ski file
+#           is created with a filename including a time stamp and ending with "_backupski.xml"
+# - replace: if the input ski file needs upgrading and \em replace is True (the default), the input ski file is
+#            overwritten by the upgraded version; otherwise it is saved as a new file using a similar filename ending
+#            with "_upgradedski.xml"
+#
 def upgradeSkiFile(inpath, *, backup=True, replace=True):
+    # load the ski file
     inpath = ut.absPath(inpath)
-    logging.info("Processing ski file {}".format(inpath))
+    try:
+        ski = sm.SkiFile(inpath)
+    except SyntaxError:
+        logging.error("File does not contain well-formed XML: {}".format(inpath))
+        return
 
-    #outpath = inpath if replace else inpath.with_name(inpath.stem+"_upgraded.ski")
+    # verify the ski file format version
+    try:
+        version = ski.getStringAttribute("/skirt-simulation-hierarchy", "format")
+    except ValueError:
+        logging.error("XML file does not have ski file format: {}".format(inpath))
+        return
+    if version!="9":
+        logging.error("Ski file is older than version 9: {}".format(inpath))
+        return
+
+    # perform the upgrade in the XML tree in memory, keeping track of whether the contents was actually changed
+    changed = "up" in inpath.name  ## stub
+
+    # save the upgraded version if needed
+    if changed:
+        if backup:
+            inpath.rename(inpath.with_name(inpath.stem + "_" + ut.timestamp() + "_backupski.xml"))
+        if replace:
+            ski.saveTo(inpath)
+            logging.warning("Ski file UPGRADED:  {}".format(inpath))
+        else:
+            outpath = inpath.with_name(inpath.stem + "_upgradedski.xml")
+            ski.saveTo(outpath)
+            logging.warning("Ski file UPGRADED:  {} --> {}".format(inpath, outpath.name))
+    else:
+        logging.info("Ski file unchanged: {}".format(inpath))
 
 # -----------------------------------------------------------------

--- a/test/functional.py
+++ b/test/functional.py
@@ -116,6 +116,10 @@ class SkirtTestSuite:
     def size(self):
         return len(self._skiPaths)
 
+    ## This function returns a list of the paths to the ski files for the test cases in this test suite
+    def skiPaths(self):
+        return self._skiPaths
+
     ## This function prepares the contents of all test case directories in the sub-suite for performing the tests.
     # Specifically, it creates \c in, \c out and \c ref directories next to the ski file, if they don't exist,
     # and it removes all files from the \c out directory (without touching any of its subdirectories, which should


### PR DESCRIPTION
**Description**
We provide the framework (command scripts and underlying functions) for upgrading SKIRT 9 ski files when incompatible changes happen to the class hierarchy and/or properties. Because no incompatible changes have occurred so far, the upgrade process does nothing for now.

**Motivation**
See issue #2. We decided to continue using XSLT, but with a slightly improved design that enables reuse of XSLT templates at least in some cases.


**Tests**
We tested the command scripts and the few provided upgrade mechanisms on some artificial upgrade situations. However, as stated above, the published version of the code does nothing.
