### PR TITLE
Remove the carbon emission lines from the Mappings dust continuum

### DIFF
--- a/storedtable/convert_sed.py
+++ b/storedtable/convert_sed.py
@@ -226,6 +226,14 @@ def convertMappingsSEDFamily(inFilePaths, outFilePaths):
     w = np.flip(w,0)
     L = np.flip(L,0)
 
+    # remove the three overly prominent carbon emission lines from the dust continuum:
+    #    [CII] line at 158 micron and [CI] lines at 370 and 609 micron
+    for wline in (158e-6, 370e-6, 609e-6):
+        i = np.argmin(np.abs(w-wline))
+        print (i)
+        w = np.delete(w, i, 0)
+        L = np.delete(L, i, 0)
+
     # write stored table
     writeStoredTable(outFilePaths[0],
           ['lambda','Z','logC','P','fPDR'], ['m','1','1','Pa','1'], ['log','log','lin','log','lin'], [w,Z,logC,P,fPDR],

--- a/storedtable/convert_sed.py
+++ b/storedtable/convert_sed.py
@@ -230,7 +230,6 @@ def convertMappingsSEDFamily(inFilePaths, outFilePaths):
     #    [CII] line at 158 micron and [CI] lines at 370 and 609 micron
     for wline in (158e-6, 370e-6, 609e-6):
         i = np.argmin(np.abs(w-wline))
-        print (i)
         w = np.delete(w, i, 0)
         L = np.delete(L, i, 0)
 


### PR DESCRIPTION
**Description**
Adjust the function that creates the stored table for the Mappings SED family templates so that it removes the three overly prominent Carbon emission lines from the dust continuum. 

**Motivation**
The problem is that these emission lines are defined in the templates through just a single point in a coarse wavelength grid. As a result they are much wider than they should be and thus they carry much more energy than physically justified.

A more detailed motivation will be provided in the pull request announcing the updated resource pack in the SKIRT repository.

**Tests**
The updated templates have been tested by investigating SKIRT results for various template parameter values.
