### PR TITLE
Return regular hostname i.o. fully qualified domain name

### DIFF
--- a/utils/envir.py
+++ b/utils/envir.py
@@ -34,6 +34,6 @@ def username():
 
 ## This function returns the name of the local host.
 def hostname():
-    return socket.getfqdn()
+    return socket.gethostname()
 
 # -----------------------------------------------------------------


### PR DESCRIPTION
**Description**
Return the regular hostname rather than the fully qualified domain name, which sometimes is long and not really intended for human consumption.
