### PR TITLE
Healpix improvements

### DIFF
--- a/simulation/do/convert_healpix.py
+++ b/simulation/do/convert_healpix.py
@@ -16,6 +16,10 @@
 #    and HammerAitoff (for the Hammer-Aitoff projection); default is Mollweide.
 #  - \em nPixelX (int): Number of pixels in the vertical direction for the generated image. The number of pixels
 #    in the horizontal direction is twice this value. Default is 250.
+#  - \em thetaCenter (float): Zenith angle of the central position relative to the original crosshair of the
+#    HEALPixSkyInstrument (in degrees). Default is 0.
+#  - \em phiCenter (float): Azimuth angle of the central position relative to the original crosshair of the
+#    HEALPixSkyInstrument (in degrees). Default is 0.
 #
 
 # -----------------------------------------------------------------
@@ -35,6 +39,14 @@ def do(
         int,
         "number of pixels to use in the vertical direction for the output image",
     ) = 250,
+    thetaCenter: (
+        float,
+        "zenith angle of the central position relative to the original crosshair (in degrees)",
+    ) = 0.0,
+    phiCenter: (
+        float,
+        "azimuth angle of the central position relative to the original crosshair (in degrees)",
+    ) = 0.0,
 ) -> "create a projected image based on a HEALPixSkyInstrument output cube":
 
     import numpy as np
@@ -64,7 +76,9 @@ def do(
     numWav = len(inputData)
     outputData = np.zeros((numWav, nPixelY, 2 * nPixelY))
     for i in range(numWav):
-        outputData[i] = healpix.getProjectionMap(inputData[i], nPixelY, projection)
+        outputData[i] = healpix.getProjectionMap(
+            inputData[i], nPixelY, projection, thetaCenter, phiCenter
+        )
 
     outputHDUL = fits.HDUList(
         [fits.PrimaryHDU(outputData, header=inputFile[0].header), inputFile[1]]

--- a/simulation/do/convert_healpix.py
+++ b/simulation/do/convert_healpix.py
@@ -57,6 +57,7 @@ def do(
     import pts.simulation.healpix as healpix
     import pathlib
     from pts.utils.error import UserError
+    import logging
 
     inputPath = pathlib.Path(inputFileName)
     if not inputPath.exists():
@@ -74,17 +75,15 @@ def do(
         raise UserError("Invalid number of pixels: {0}!".format(nPixelY))
 
     inputFile = fits.open(inputPath)
+    logging.info("Opened input file {0}".format(inputPath))
 
-    inputData = inputFile[0].data
-    numWav = len(inputData)
-    outputData = np.zeros((numWav, nPixelY, 2 * nPixelY))
-    for i in range(numWav):
-        outputData[i] = healpix.getProjectionMap(
-            inputData[i], nPixelY, projection, thetaCenter, phiCenter
-        )
+    hData = healpix.HEALPixGrid(inputFile[0].data)
+    hData.printInfo()
+    outputData = hData.getProjectionMap(nPixelY, projection, thetaCenter, phiCenter)
 
     outputHDUL = fits.HDUList(
         [fits.PrimaryHDU(outputData, header=inputFile[0].header), inputFile[1]]
     )
 
     outputHDUL.writeto(outputPath)
+    logging.info("Wrote output file {0}".format(outputPath))

--- a/simulation/do/convert_healpix.py
+++ b/simulation/do/convert_healpix.py
@@ -17,9 +17,10 @@
 #  - \em nPixelX (int): Number of pixels in the vertical direction for the generated image. The number of pixels
 #    in the horizontal direction is twice this value. Default is 250.
 #  - \em thetaCenter (float): Zenith angle of the central position relative to the original crosshair of the
-#    HEALPixSkyInstrument (in degrees). Default is 0.
+#    HEALPixSkyInstrument (in degrees). Corresponds to a vertical rotation that goes downward in the right half
+#    of the image. Default is 0.
 #  - \em phiCenter (float): Azimuth angle of the central position relative to the original crosshair of the
-#    HEALPixSkyInstrument (in degrees). Default is 0.
+#    HEALPixSkyInstrument (in degrees). Corresponds to a horizontal rotation to the right. Default is 0.
 #
 
 # -----------------------------------------------------------------
@@ -41,11 +42,13 @@ def do(
     ) = 250,
     thetaCenter: (
         float,
-        "zenith angle of the central position relative to the original crosshair (in degrees)",
+        "zenith angle of the central position relative to the original crosshair (in degrees),"
+        " corresponding to a vertical rotation that goes downward in the right half of the image",
     ) = 0.0,
     phiCenter: (
         float,
-        "azimuth angle of the central position relative to the original crosshair (in degrees)",
+        "azimuth angle of the central position relative to the original crosshair (in degrees),"
+        " corresponding to a horizontal rotation to the right",
     ) = 0.0,
 ) -> "create a projected image based on a HEALPixSkyInstrument output cube":
 

--- a/simulation/do/healpix_to_planck.py
+++ b/simulation/do/healpix_to_planck.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+# -*- coding: utf8 -*-
+# *****************************************************************
+# **       PTS -- Python Toolkit for working with SKIRT          **
+# **       © Astronomical Observatory, Ghent University          **
+# *****************************************************************
+
+## \package pts.simulation.do.healpix_to_planck Create a Planck compatible all-sky FITS
+# file based on the raw output of a HEALPixSkyInstrument.
+#
+# This script converts the given HEALPixSkyInstrument output FITS file to a Planck compatible
+# all-sky FITS file. The image data in the original FITS file is moved to a FITS table, so that
+# the resulting FITS file can be analysed using the same tools as were used for Planck.
+#
+# The function takes the following arguments:
+#  - \em inputFileName (string): the name of the file containing the raw HEALPix data cube
+#  - \em outputFileName (string): the name of the generated Planck compatible FITS file
+#
+
+# -----------------------------------------------------------------
+
+
+def do(
+    inputFileName: (
+        str,
+        "HEALPixSkyInstrument output image containing the raw HEALPix pixel data",
+    ),
+    outputFileName: (
+        str,
+        "output file containing a Planck compatible version of the data cube",
+    ),
+) -> "create a Planck compatible FITS file from a raw HEALPixSkyInstrument output file":
+
+    import numpy as np
+    import astropy.io.fits as fits
+    import pts.simulation.healpix as healpix
+    import pathlib
+    from pts.utils.error import UserError
+    import logging
+
+    inputPath = pathlib.Path(inputFileName)
+    if not inputPath.exists():
+        raise UserError("Input file does not exist!")
+    if not inputPath.suffix == ".fits":
+        raise UserError("Input file is not a FITS file!")
+
+    outputPath = pathlib.Path(outputFileName)
+    if outputPath.exists():
+        raise UserError("Output file already exists!")
+    if not outputPath.suffix == ".fits":
+        raise UserError("Output file is not a FITS file!")
+
+    inputFile = fits.open(inputPath)
+    logging.info("Opened input file {0}".format(inputPath))
+
+    hData = healpix.HEALPixGrid(inputFile[0].data)
+    hData.printInfo()
+    j, i = hData.getPixelIndices()
+    validCube = hData.getPixel(j, i)
+    logging.info("Extracted actual data cube of shape {0}".format(validCube.shape))
+
+    wav = inputFile[1].data[:]
+
+    if len(validCube.shape) == 1:
+        validCube.reshape((1, validCube.shape[0]))
+
+    cols = []
+    for iCol in range(len(wav)):
+        col = fits.Column(
+            name="{0:.0f} mu".format(wav[iCol][0]),
+            format="D",
+            array=validCube[iCol],
+            unit=inputFile[0].header["BUNIT"],
+        )
+        cols.append(col)
+    hdu = fits.BinTableHDU.from_columns(cols)
+    hdu.header["PIXTYPE"] = "HEALPIX"
+    hdu.header["ORDERING"] = "RING"
+    hdu.header["NSIDE"] = hData._NSide
+
+    outputHDUL = fits.HDUList([fits.PrimaryHDU(), hdu])
+
+    outputHDUL.writeto(outputPath)
+    logging.info("Wrote output file {0}".format(outputPath))

--- a/simulation/healpix.py
+++ b/simulation/healpix.py
@@ -7,196 +7,254 @@
 
 ## \package pts.simulation.healpix Handling of HEALPix grids
 #
-# This module offers support for projecting HEALPix grids output by the HEALPixSkyInstrument.
+# This module offers functionality to work with HEALPix grids output by the HEALPixSkyInstrument.
 #
 
 # -----------------------------------------------------------------
 
 import numpy as np
 from pts.utils.error import UserError
+import logging
 
-# -----------------------------------------------------------------
-
-
-## This function returns the index arrays corresponding to the given input zenith and azimuth angles for a
-# HEALPix grid in SKIRT's modified ring order with the given Nside parameter.
+## This class represents a HEALPix grid. It contains a reference to the raw
+# HEALPixSkyInstrument data cube and some additional geometrical information
+# about the grid that is derived from it.
 #
-# For each pair of input angles, the returned pair of output indices points to the pixel that contains
-# those angles. Using those indices to access the raw HEALPix data will return the corresponding pixel
-# value.
+# It offer functionality to access, manipulate and project the HEALPix pixels.
 #
-# Note that the code here is (and always should be) identical to the implementation used internally by
-# SKIRT to guarantee consistency. We do however make use of NumPy arrays and NumPy array indexing for
-# increased efficiency.
-#
-def getHEALPixIndices(theta, phi, Nside):
-    z = np.cos(theta)
-    za = np.abs(z)
-    tt = np.mod(2.0 * phi / np.pi, 4.0)
+class HEALPixGrid:
 
-    # empty ring (j) and pixel-in-ring (i) index arrays
-    j = np.zeros(za.shape, dtype=int)
-    i = np.zeros(za.shape, dtype=int)
+    ## Constructor.
+    #
+    # Responsible for initialising the geometrical information about the HEALPix grid.
+    #
+    def __init__(self, HEALPixCube):
+        self._HEALPixCube = HEALPixCube
+        self._NSide = HEALPixCube.shape[-1] // 4
+        self._order = int(np.log2(self._NSide))
 
-    # we need different expressions for HEALPix pixels in the equatorial plane
-    # (za <= 2./3.) and in the polar caps (za > 2./3.)
-    # to exploit NumPy efficiency, we use index arrays
-
-    # equatorial plane
-    ieq = za <= 2.0 / 3.0
-    t1 = Nside * (0.5 + tt[ieq])
-    t2 = 0.75 * Nside * z[ieq]
-    jp = np.floor(t1 - t2)
-    jm = np.floor(t1 + t2)
-    j[ieq] = Nside + 1 + jp - jm
-    kshift = 1 - np.bitwise_and(j[ieq], 1)
-    t1 = jp + jm + kshift + 1 + 7 * Nside
-    i[ieq] = np.bitwise_and(np.right_shift(t1.astype(int), 1), 4 * Nside - 1)
-    j[ieq] += Nside - 2
-
-    # polar caps
-    ipol = ~ieq
-    ntt = np.floor(tt[ipol])
-    tp = tt[ipol] - ntt
-    tmp = np.zeros(tp.shape)
-    # deal with small values of sin(theta)
-    tmp[za[ipol] >= 0.99] = (
-        Nside
-        * np.sin(theta[ipol & (za >= 0.99)])
-        / np.sqrt((1.0 + za[ipol & (za >= 0.99)]) / 3.0)
-    )
-    tmp[za[ipol] < 0.99] = Nside * np.sqrt(3.0 * (1 - za[ipol & (za < 0.99)]))
-    jp = np.floor(tp * tmp)
-    jm = np.floor((1.0 - tp) * tmp)
-    j[ipol] = jp + jm + 1
-    i[ipol] = np.floor(tt[ipol] * j[ipol])
-    # distinguish between north and south pole
-    j[ipol & (z > 0)] -= 1
-    j[ipol & (z < 0)] = 4 * Nside - j[ipol & (z < 0)] - 1
-
-    return j, i
-
-
-## This function returns the projection of the given HEALPix data map, using the given
-# number of vertical pixels for the resulting projection image, and the given projection
-# transformation. The optional parameters thetaCenter and phiCenter allow to select a
-# different central position than the original crosshair of the HEALPixSkyInstrument.
-#
-# The function first sets up the linear coordinates for the projection image and then converts
-# them to the appropriate zenith and azimuth angles using the appropriate projection. These angles
-# are then rotated according to thetaCenter and phiCenter so that they point to the correct angles
-# on the rotated HEALPix sphere. Finally, the angles are passed on to getHEALPixIndices() to get
-# the corresponding HEALPix pixels.
-#
-# Because of the nature of the Mollweide projection, some pixels in the four corners of the output
-# image are unused. The values in these pixels are set to zero.
-#
-# The angles thetaCenter and phiCenter lead to vertical and horizontal rotations respectively. The
-# horizontal rotation is simply to the right. The vertical rotation goes upward in the left part of
-# the image and downward in the right part. Pixels that rotate through the pole move from the left
-# part to the right part. Due to the projection, thetaCenter can go through a full 360 degrees
-# rotation before the projection image is the same; thetaCenter angles larger than 180 degrees
-# correspond to projection images for smaller thetaCenter values that are seen upside down.
-#
-def getProjectionMap(
-    HEALPixCube, nPixelY, projection="Mollweide", thetaCenter=0.0, phiCenter=0.0
-):
-    # derive the HEALPix parameters from the image size
-    Nside = HEALPixCube.shape[1] // 4
-
-    # convert the azimuth angle from degrees to radians
-    phiCenter *= np.pi / 180.0
-    thetaCenter *= np.pi / 180.0
-
-    # make sure we oversample the HEALPix pixels initially, we will resample after the projection
-    if nPixelY < 2 * Nside:
-        nPixelYHigh = 2 * Nside
-        nPixelYHigh += nPixelY - nPixelYHigh % nPixelY
-        resFac = nPixelYHigh // nPixelY
-    else:
-        nPixelYHigh = nPixelY
-        resFac = 1
-
-    # initialize the image pixels
-    nPixelXHigh = 2 * nPixelYHigh
-    yMin = -1.0 + 1.0 / nPixelYHigh
-    dY = 2.0 / nPixelYHigh
-    xMin = -2.0 + 2.0 / nPixelXHigh
-    dX = 4.0 / nPixelXHigh
-    y, x = np.mgrid[yMin:1.0:dY, xMin:2.0:dX]
-
-    # create an empty pixel map
-    image = np.zeros(x.shape)
-
-    if projection == "Mollweide":
-        # compute the Mollweide angles for each pixel
-        temp = np.arcsin(y)
-        theta = np.arcsin((2.0 * temp + np.sin(2.0 * temp)) / np.pi) + 0.5 * np.pi
-        phi = np.pi + 0.5 * np.pi * x / np.cos(temp)
-
-        # filter out invalid angles in the corners
-        iValid = (0.5 * x) ** 2 + (y) ** 2 < 1.0
-        theta = theta[iValid]
-        phi = phi[iValid]
-    elif projection == "HammerAitoff":
-        x *= np.sqrt(2.0)
-        y *= np.sqrt(2.0)
-        # compute the Hammer-Aitoff angles for each pixel
-        temp = np.sqrt(1.0 - (0.25 * x) ** 2 - (0.5 * y) ** 2)
-        theta = np.arcsin(temp * y) + 0.5 * np.pi
-        phi = 2.0 * np.arctan(0.5 * temp * x / (2.0 * temp ** 2 - 1.0)) + np.pi
-
-        # filter out invalid angles in the corners
-        iValid = (0.5 * x) ** 2 + (y) ** 2 < 2.0
-        theta = theta[iValid]
-        phi = phi[iValid]
-    else:
-        raise UserError(
-            "Unknown projection ("
-            + projection
-            + ")! Possible values are Mollweide, HammerAitoff."
+    ## Print some information about the HEALPix grid to the console.
+    def printInfo(self):
+        logging.info(
+            "HEALPix grid has side length {0} and order {1}.".format(
+                self._NSide, self._order
+            )
+        )
+        logging.info(
+            "It contains {0} variables per pixel.".format(self._HEALPixCube.shape[0])
         )
 
-    # invert the azimuth angle to account for the SKIRT orientation convention
-    phi = 2.0 * np.pi - phi
+    ## This function returns the index arrays corresponding to the given input zenith and azimuth angles for the
+    # HEALPix grid in SKIRT's modified ring order.
+    #
+    # For each pair of input angles, the returned pair of output indices points to the pixel that contains
+    # those angles. Using those indices to access the raw HEALPix data will return the corresponding pixel
+    # value.
+    #
+    # Note that the code here is (and always should be) identical to the implementation used internally by
+    # SKIRT to guarantee consistency. We do however make use of NumPy arrays and NumPy array indexing for
+    # increased efficiency.
+    #
+    def getHEALPixIndices(self, theta, phi):
 
-    # we have successfully applied the projection to obtain the angular coordinates of each
-    # pixel of the projection image on the unit sphere, centred on (theta, phi) = (0, 0)
-    # now we need to transform these angles to the unit sphere centred on (thetaCenter, phiCenter)
-    # we do this by applying two rotations:
-    #  - a rotation over phiCenter along the z axis. This rotation only affects phi
-    phi += phiCenter
-    #  - a rotation over thetaCenter along the (rotated) x axis. This rotation needs to be done
-    #    in Cartesian space
-    sinTheta = np.sin(theta)
-    x = sinTheta * np.cos(phi)
-    y = sinTheta * np.sin(phi)
-    z = np.cos(theta)
-    sinThetaCenter = np.sin(thetaCenter)
-    cosThetaCenter = np.cos(thetaCenter)
-    temp = y * cosThetaCenter + z * sinThetaCenter
-    z = -y * sinThetaCenter + z * cosThetaCenter
-    y = temp
-    phi = np.arctan2(y, x)
-    theta = np.arccos(z)
+        # make sure the input angles are NumPy arrays
+        if not theta is np.ndarray:
+            theta = np.array(theta)
+        if not phi is np.ndarray:
+            phi = np.array(phi)
 
-    # make sure the final angles are within range for the HEALPix grid
-    phi = np.mod(phi, 2.0 * np.pi)
-    theta = np.mod(theta, np.pi)
+        z = np.cos(theta)
+        za = np.abs(z)
+        tt = np.mod(2.0 * phi / np.pi, 4.0)
 
-    j, i = getHEALPixIndices(theta, phi, Nside)
+        # empty ring (j) and pixel-in-ring (i) index arrays
+        j = np.zeros(za.shape, dtype=int)
+        i = np.zeros(za.shape, dtype=int)
 
-    # copy the HEALPix pixel values into the corresponding image pixels (only for valid pixels)
-    image[iValid] = HEALPixCube[j, i]
+        # we need different expressions for HEALPix pixels in the equatorial plane
+        # (za <= 2./3.) and in the polar caps (za > 2./3.)
+        # to exploit NumPy efficiency, we use index arrays
 
-    # resample the image onto the desired resolution
-    if resFac > 1:
-        temp = image.reshape(
-            (image.shape[0] // resFac, resFac, image.shape[1] // resFac, resFac)
+        # equatorial plane
+        ieq = za <= 2.0 / 3.0
+        t1 = self._NSide * (0.5 + tt[ieq])
+        t2 = 0.75 * self._NSide * z[ieq]
+        jp = np.floor(t1 - t2)
+        jm = np.floor(t1 + t2)
+        j[ieq] = self._NSide + 1 + jp - jm
+        kshift = 1 - np.bitwise_and(j[ieq], 1)
+        t1 = jp + jm + kshift + 1 + 7 * self._NSide
+        i[ieq] = np.bitwise_and(np.right_shift(t1.astype(int), 1), 4 * self._NSide - 1)
+        j[ieq] += self._NSide - 2
+
+        # polar caps
+        ipol = ~ieq
+        ntt = np.floor(tt[ipol])
+        tp = tt[ipol] - ntt
+        tmp = np.zeros(tp.shape)
+        # deal with small values of sin(theta)
+        tmp[za[ipol] >= 0.99] = (
+            self._NSide
+            * np.sin(theta[ipol & (za >= 0.99)])
+            / np.sqrt((1.0 + za[ipol & (za >= 0.99)]) / 3.0)
         )
-        image = np.sum(temp, axis=(1, 3))
+        tmp[za[ipol] < 0.99] = self._NSide * np.sqrt(3.0 * (1 - za[ipol & (za < 0.99)]))
+        jp = np.floor(tp * tmp)
+        jm = np.floor((1.0 - tp) * tmp)
+        j[ipol] = jp + jm + 1
+        i[ipol] = np.floor(tt[ipol] * j[ipol])
+        # distinguish between north and south pole
+        j[ipol & (z > 0)] -= 1
+        j[ipol & (z < 0)] = 4 * self._NSide - j[ipol & (z < 0)] - 1
 
-    return image
+        return j, i
 
+    ## This function returns the projection of the HEALPix data map, using the given
+    # number of vertical pixels for the resulting projection image, and the given projection
+    # transformation. The optional parameters thetaCenter and phiCenter allow to select a
+    # different central position than the original crosshair of the HEALPixSkyInstrument.
+    #
+    # The function first sets up the linear coordinates for the projection image and then converts
+    # them to the appropriate zenith and azimuth angles using the appropriate projection. These angles
+    # are then rotated according to thetaCenter and phiCenter so that they point to the correct angles
+    # on the rotated HEALPix sphere. Finally, the angles are passed on to getHEALPixIndices() to get
+    # the corresponding HEALPix pixels.
+    #
+    # Because of the nature of the Mollweide projection, some pixels in the four corners of the output
+    # image are unused. The values in these pixels are set to zero.
+    #
+    # The angles thetaCenter and phiCenter lead to vertical and horizontal rotations respectively. The
+    # horizontal rotation is simply to the right. The vertical rotation goes upward in the left part of
+    # the image and downward in the right part. Pixels that rotate through the pole move from the left
+    # part to the right part. Due to the projection, thetaCenter can go through a full 360 degrees
+    # rotation before the projection image is the same; thetaCenter angles larger than 180 degrees
+    # correspond to projection images for smaller thetaCenter values that are seen upside down.
+    #
+    def getProjectionMap(
+        self, nPixelY, projection="Mollweide", thetaCenter=0.0, phiCenter=0.0
+    ):
+
+        # convert the azimuth angle from degrees to radians
+        phiCenter *= np.pi / 180.0
+        thetaCenter *= np.pi / 180.0
+
+        # make sure we oversample the HEALPix pixels initially, we will resample after the projection
+        if nPixelY < 2 * self._NSide:
+            nPixelYHigh = 2 * self._NSide
+            nPixelYHigh += nPixelY - nPixelYHigh % nPixelY
+            resFac = nPixelYHigh // nPixelY
+        else:
+            nPixelYHigh = nPixelY
+            resFac = 1
+
+        # initialize the image pixels
+        nPixelXHigh = 2 * nPixelYHigh
+        yMin = -1.0 + 1.0 / nPixelYHigh
+        dY = 2.0 / nPixelYHigh
+        xMin = -2.0 + 2.0 / nPixelXHigh
+        dX = 4.0 / nPixelXHigh
+        y, x = np.mgrid[yMin:1.0:dY, xMin:2.0:dX]
+
+        # create an empty pixel map
+        if len(self._HEALPixCube.shape) == 2:
+            image = np.zeros(x.shape)
+        elif len(self._HEALPixCube.shape) == 3:
+            image = np.zeros((self._HEALPixCube.shape[0], x.shape[0], x.shape[1]))
+        else:
+            raise ValueError(
+                "Expected HEALPixCube of dimension 2 or 3, but instead got cube with shape {0}".format(
+                    self._HEALPixCube.shape
+                )
+            )
+
+        logging.info(
+            "Creating a projected data cube with shape {0}".format(image.shape)
+        )
+
+        if projection == "Mollweide":
+            # compute the Mollweide angles for each pixel
+            temp = np.arcsin(y)
+            theta = np.arcsin((2.0 * temp + np.sin(2.0 * temp)) / np.pi) + 0.5 * np.pi
+            phi = np.pi + 0.5 * np.pi * x / np.cos(temp)
+
+            # filter out invalid angles in the corners
+            iValid = (0.5 * x) ** 2 + (y) ** 2 < 1.0
+            theta = theta[iValid]
+            phi = phi[iValid]
+        elif projection == "HammerAitoff":
+            x *= np.sqrt(2.0)
+            y *= np.sqrt(2.0)
+            # compute the Hammer-Aitoff angles for each pixel
+            temp = np.sqrt(1.0 - (0.25 * x) ** 2 - (0.5 * y) ** 2)
+            theta = np.arcsin(temp * y) + 0.5 * np.pi
+            phi = 2.0 * np.arctan(0.5 * temp * x / (2.0 * temp ** 2 - 1.0)) + np.pi
+
+            # filter out invalid angles in the corners
+            iValid = (0.5 * x) ** 2 + (y) ** 2 < 2.0
+            theta = theta[iValid]
+            phi = phi[iValid]
+        else:
+            raise UserError(
+                "Unknown projection ("
+                + projection
+                + ")! Possible values are Mollweide, HammerAitoff."
+            )
+
+        # invert the azimuth angle to account for the SKIRT orientation convention
+        phi = 2.0 * np.pi - phi
+
+        # we have successfully applied the projection to obtain the angular coordinates of each
+        # pixel of the projection image on the unit sphere, centred on (theta, phi) = (0, 0)
+        # now we need to transform these angles to the unit sphere centred on (thetaCenter, phiCenter)
+        # we do this by applying two rotations:
+        #  - a rotation over phiCenter along the z axis. This rotation only affects phi
+        phi += phiCenter
+        #  - a rotation over thetaCenter along the (rotated) x axis. This rotation needs to be done
+        #    in Cartesian space
+        sinTheta = np.sin(theta)
+        x = sinTheta * np.cos(phi)
+        y = sinTheta * np.sin(phi)
+        z = np.cos(theta)
+        sinThetaCenter = np.sin(thetaCenter)
+        cosThetaCenter = np.cos(thetaCenter)
+        temp = y * cosThetaCenter + z * sinThetaCenter
+        z = -y * sinThetaCenter + z * cosThetaCenter
+        y = temp
+        phi = np.arctan2(y, x)
+        theta = np.arccos(z)
+
+        # make sure the final angles are within range for the HEALPix grid
+        phi = np.mod(phi, 2.0 * np.pi)
+        theta = np.mod(theta, np.pi)
+
+        j, i = self.getHEALPixIndices(theta, phi)
+
+        # copy the HEALPix pixel values into the corresponding image pixels (only for valid pixels)
+        if len(self._HEALPixCube.shape) == 2:
+            image[iValid] = self._HEALPixCube[j, i]
+        elif len(self._HEALPixCube.shape) == 3:
+            image[:, iValid] = self._HEALPixCube[:, j, i]
+
+        # resample the image onto the desired resolution
+        if resFac > 1:
+            if len(self._HEALPixCube.shape) == 2:
+                temp = image.reshape(
+                    (image.shape[0] // resFac, resFac, image.shape[1] // resFac, resFac)
+                )
+                image = np.sum(temp, axis=(1, 3))
+            elif len(self._HEALPixCube.shape) == 3:
+                temp = image.reshape(
+                    (
+                        image.shape[0],
+                        image.shape[1] // resFac,
+                        resFac,
+                        image.shape[2] // resFac,
+                        resFac,
+                    )
+                )
+                image = np.sum(temp, axis=(2, 4))
+            logging.info("Resampled projected cube to shape {0}".format(image.shape))
+
+        return image
 
 # -----------------------------------------------------------------

--- a/simulation/healpix.py
+++ b/simulation/healpix.py
@@ -538,7 +538,7 @@ class HEALPixGrid:
         if self._tree is None:
             logging.info(
                 "Creating KD tree to speed up spatial queries."
-                "This might take a while..."
+                " This might take a while..."
             )
             positions = self.getPositions()
             self._tree = cKDTree(positions)


### PR DESCRIPTION
**Description**
This pull request contains a thorough refactoring of the HEALPix support. A HEALPix grid is now represented internally as an object that caches some information for more efficient access. This object has functionality to access the pixels in various ways, including the option to retrieve all pixels within an annulus around a pixel. The existing HEALPix projection script has been extended with an option to rotate the sky to an arbitrary new cross hair, and has been updated so that the total flux is now conserved, independent of the chosen resolution. A new conversion script has been added to convert the SKIRT HEALPix output into a FITS format that is compatible with the official HEALPix software and tools as used by e.g. Planck.

**Motivation**
These scripts were developed during an attempt to repeat some of the Planck analysis of the Milky Way data with synthetic SKIRT images, and have proven useful to access the HEALPix grid data.

**Tests**
The new functionality has been thoroughly tested during the aforementioned analysis and appears to work as expected.
A highlight of the new functionality is the ability to produce animations like this:
![proj](https://user-images.githubusercontent.com/7336967/86913656-dd08bc80-c116-11ea-917c-d7a6732434b3.gif)

**Guidelines**
All code has been automatically formatted using `black`.