### PR TITLE
add function to copy stored table into SKIRT resource pack

### DIFF
--- a/storedtable/conversionspec.py
+++ b/storedtable/conversionspec.py
@@ -27,6 +27,7 @@ import pts.utils as ut
 
 # import the modules that implement the conversions
 from .convert_band import *
+from .convert_copy import *
 from .convert_enthalpies import *
 from .convert_opticalprops import *
 from .convert_sed import *

--- a/storedtable/convert_copy.py
+++ b/storedtable/convert_copy.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+# -*- coding: utf8 -*-
+# *****************************************************************
+# **       PTS -- Python Toolkit for working with SKIRT          **
+# **       © Astronomical Observatory, Ghent University          **
+# *****************************************************************
+
+## \package pts.storedtable.convert_copy Function to "convert" stored table files by simply copying them
+#
+# The function in this module has the same signature as the functions for converting some type of data
+# into SKIRT stored table format, however, it expects its input files to already have the correct format.
+
+# -----------------------------------------------------------------
+
+import shutil
+
+# -----------------------------------------------------------------
+
+## This function expects a sequence of input file paths and corresponding output file paths.
+# It simply copies each of the input files to corresponding output file path.
+# In other words, the function has the same signature as the functions for converting some type of data
+# into SKIRT stored table format, however, it expects its input files to already have the correct format.
+#
+def copyWithoutConversion(inFilePaths, outFilePaths):
+    for inFilePath, outFilePath in zip(inFilePaths, outFilePaths):
+        shutil.copyfile(inFilePath, outFilePath)
+
+# -----------------------------------------------------------------


### PR DESCRIPTION
**Description**
Add a SKIRT resource "conversion" function that simply copies the original stored table.

**Motivation**
Resources originally supplied in the correct SKIRt stored table format can now be treated in a similar way as other resources.

**Tests**
The new capability has been tested with the built-in spheroidal grain emission properties generated from CosTuuM.
