### PR TITLE
Allow plotting spectral resolution from any SKIRT instrument or probe output with a wavelength grid

### DIFF
--- a/visual/plotcurves.py
+++ b/visual/plotcurves.py
@@ -205,7 +205,8 @@ def plotSources(simulation, minWavelength=None, maxWavelength=None, decades=None
 # ----------------------------------------------------------------------
 
 ## This function creates a plot of the spectral resolution \f$R=\lambda/\Delta\lambda\f$ of a wavelength grid
-# loaded from a SKIRT stored table (".stab") or a SKIRT text column file (".dat") that includes a wavelength axis.
+# loaded from a SKIRT stored table (".stab"), a SKIRT text column file (".dat") that includes a wavelength axis,
+# or a SKIRT instrument or probe data cube that includes a wavelength axis.
 #
 # By default, the figure is saved in the current directory, using the name of the input file but
 # with the ".pdf" filename extension. This can be overridden with the out* arguments as described for the
@@ -226,8 +227,13 @@ def plotSpectralResolution(inFilePath, minWavelength=None, maxWavelength=None, d
         if "wavelength" not in sm.getColumnDescriptions(inFilePath)[0].lower():
             raise ValueError("First text column is not labeled 'wavelength': {}".format(inFilePath))
         grid = sm.loadColumns(inFilePath, "1")[0]
+    elif inFilePath.suffix.lower() == ".fits":
+        axes = sm.getFitsAxes(inFilePath)
+        if len(axes) != 3:
+            raise ValueError("FITS file does not have embedded wavelength axis")
+        grid = axes[2]
     else:
-        raise ValueError("Filename does not have the .stab or .dat extension: {}".format(inFilePath))
+        raise ValueError("Filename does not have the .stab, .dat, or .fits extension: {}".format(inFilePath))
 
     # calculate the spectral resolution
     R = grid[:-1] / (grid[1:] - grid[:-1])

--- a/visual/plotcurves.py
+++ b/visual/plotcurves.py
@@ -223,7 +223,7 @@ def plotSpectralResolution(inFilePath, minWavelength=None, maxWavelength=None, d
             raise ValueError("No wavelength axis in stored table: {}".format(inFilePath))
         grid = table["lambda"]
     elif inFilePath.suffix.lower() == ".dat":
-        if not sm.getColumnDescriptions(inFilePath)[0].lower().startswith("wavelength"):
+        if "wavelength" not in sm.getColumnDescriptions(inFilePath)[0].lower():
             raise ValueError("First text column is not labeled 'wavelength': {}".format(inFilePath))
         grid = sm.loadColumns(inFilePath, "1")[0]
     else:


### PR DESCRIPTION
**Description**
The `pts plot_spectral_resolution` command has been extended to allow plotting the spectral resolution for any SKIRT instrument or probe output file that embeds a wavelength grid. It now supports text files (`.dat`) with wavelength as the first column and data cubes (`.fits`) with wavelength as the third axis, in addition to the existing support for SKIRT stored table files (`.stab`) that include a wavelength axis.

**Motivation**
New wavelength grid types being added to SKIRT allow the creation of more and more complex grids with a resolution that varies along the spectral range. This creates a need for users (and testers) to visualize the spectral resolution of the configured grids.
