### PR TITLE
Adjust function to create MeanInterStellarDustMix resource table

### DIFF
--- a/storedtable/convert_singlegrain.py
+++ b/storedtable/convert_singlegrain.py
@@ -48,6 +48,10 @@ def convertMeanInterstellarOpticalProps(inFilePaths, outFilePaths):
     sa = (1-a)*se
     ss = a*se
 
+    # replace asymmetry parameter values in x-ray range by analytical approximation 1 - lambda in micron
+    mask = w < 1e-8
+    g[mask] = 1 - w[mask]*1e6
+
     # determine dust mass
     mu = np.zeros_like(w) + 1.870e-29     # in kg/H
 


### PR DESCRIPTION
**Description**
The function that creates the SKIRT resource table for the `MeanInterStellarDustMix` is adjusted to replace the values of the scattering asymmetry parameter for X-ray wavelengths (<0.01 micron) by an improved approximation. For more information, see the corresponding [SKIRT pull request](https://github.com/SKIRT/SKIRT9/pull/144).

**Motivation**
This allows the MeanInterStellarDustMix to be used in the soft X-ray wavelength range.