### PR TITLE
Properly parse logged simulation time

### DIFF
--- a/simulation/text.py
+++ b/simulation/text.py
@@ -53,9 +53,12 @@ def getQuantityFromFile(path, trigger, header):
             # select the line
             if triggered < len(triggers) and triggers[triggered] in line: triggered += 1
             elif triggered==len(triggers) and header in line:
-                # remove section between parentheses
-                if line.strip().endswith(')'):
+                line = line.strip()
+                # remove section between parentheses and/or trailing "."
+                if line.endswith(')') or line.endswith(').'):
                     line = line[:line.rfind('(')]
+                if line.endswith('.'):
+                    line = line[:-1]
                 segments = line.split()
                 if len(segments) >= 2:
                     try:


### PR DESCRIPTION
**Description**
This is a minor fix to the function that locates and parses numbers in SKIRT log files. It now properly parses the simulation time (the line ends with "s." rather than "s").

**Motivation**
Allow automatic processing of the logged simulation time.

