### PR TITLE
Provide ski file upgrade for renamed iterateMediumState property

### DIFF
--- a/skiupgrade/skiupgrade.py
+++ b/skiupgrade/skiupgrade.py
@@ -227,6 +227,9 @@ def _getUpgradeDefinitions():
         # AllSkyProjectionForm
         _changeToFormProbe("OpticalDepthMapProbe", "OpacityProbe", "AllSkyProjectionForm",
                             dict(probeName=None, wavelength=None, probeAfter=None), propsAllSkyProjectionForm),
+
+        # SKIRT update (aug 2022): revise dynamic medium state concepts; rename iterateMediumState property
+        _changeScalarPropertyName("MonteCarloSimulation", "iterateMediumState", "iteratePrimaryEmission"),
     ]
 
 # --------- handling probe to form-probe updates


### PR DESCRIPTION
**Description**
A forthcoming SKIRT update renames the _iterateMediumState_ property of the `MonteCarloSimulation` item to _iteratePrimaryEmission_, reflecting the revised dynamic medium state concepts introduced in that update. More information about these changes will be provided in the SKIRT pull request. The current PTS pull request provides an automated upgrade procedure for existing SKIRT 9 ski files. Alternatively, the property name can be adjusted manually.

**Motivation**
Users can run this upgrade procedure rather than having to perform manual edits.

**Tests**
All functional test ski files have been successfully upgraded using this procedure.

**User guide**
Install PTS if you haven't done so and pull the latest version to your local repository. Then, to upgrade all ski files in the current directory, enter:

`pts upgrade_ski .`

To process ski files in another directory, replace the `.` by that directory's path. In both cases, a backup copy of the original ski file is placed in the same directory (with a filename including a time stamp) before the upgrade is performed.
