### PR TITLE
Allow specifying the units of the wavelength range in relevant plot commands

### DIFF
--- a/visual/do/plot_seds.py
+++ b/visual/do/plot_seds.py
@@ -12,8 +12,9 @@
 #                                                 or "." for the current directory
 #  - \em prefix (string): the prefix of the simulation to handle; by default handles all simulations in the directory
 #  - \em instr (string): the name of the instrument to handle; by default handles all instruments in the simulation
-#  - \em wmin (float): smallest wavelength on the horizontal axis, in micron; default is 0.1 micron
-#  - \em wmax (float): largest wavelength on the horizontal axis, in micron; default is 1000 micron
+#  - \em wmin (float): smallest wavelength on the horizontal axis; default is 0.1
+#  - \em wmax (float): largest wavelength on the horizontal axis; default is 1000
+#  - \em unit (string): unit of the wavelength limits (any spectral unit); default is micron
 #  - \em dex (float): if specified, the number of decades to be plotted on the vertical axis; default is 5
 #
 # If there is only a single instrument (because the instrument name was specified or because the simulation only has
@@ -29,20 +30,20 @@
 def do( simDirPath : (str,"SKIRT simulation output directory"),
         prefix : (str,"SKIRT simulation prefix") = "",
         instr : (str,"instrument name") = "",
-        wmin : (float,"smallest wavelength on the horizontal axis, in micron") = 0.1,
-        wmax : (float,"largest wavelength on the horizontal axis, in micron") = 1000.,
+        wmin : (float,"smallest wavelength on the horizontal axis") = 0.1,
+        wmax : (float,"largest wavelength on the horizontal axis") = 1000.,
+        unit: (str,"unit of the wavelength limits (any spectral unit)") = "micron",
         dex : (float,"number of decades to be plotted on the vertical axis") = 5,
         ) -> "plot the SEDs produced by one or more SKIRT simulations":
 
-    import astropy.units as u
     import pts.simulation as sm
     import pts.visual as vis
 
     for sim in sm.createSimulations(simDirPath, prefix if len(prefix)>0 else None):
         if len(instr)>0:
             instrument = [ ins for ins in sim.instruments() if ins.name() == instr ]
-            vis.plotSeds(instrument, minWavelength=wmin * u.micron, maxWavelength=wmax * u.micron, decades=dex)
+            vis.plotSeds(instrument, minWavelength=wmin*sm.unit(unit), maxWavelength=wmax*sm.unit(unit), decades=dex)
         else:
-            vis.plotSeds(sim, minWavelength=wmin * u.micron, maxWavelength=wmax * u.micron, decades=dex)
+            vis.plotSeds(sim, minWavelength=wmin*sm.unit(unit), maxWavelength=wmax*sm.unit(unit), decades=dex)
 
 # ----------------------------------------------------------------------

--- a/visual/do/plot_sources.py
+++ b/visual/do/plot_sources.py
@@ -19,8 +19,9 @@
 #  - \em simDirPath (positional string argument): the path to the SKIRT simulation output directory,
 #                                                 or "." for the current directory
 #  - \em prefix (string): the prefix of the simulation to handle; by default handles all simulations in the directory
-#  - \em wmin (float): smallest wavelength on the horizontal axis, in micron; default is 0.1 micron
-#  - \em wmax (float): largest wavelength on the horizontal axis, in micron; default is 1000 micron
+#  - \em wmin (float): smallest wavelength on the horizontal axis; default is 0.1
+#  - \em wmax (float): largest wavelength on the horizontal axis; default is 1000
+#  - \em unit (string): unit of the wavelength limits (any spectral unit); default is micron
 #  - \em dex (float): if specified, the number of decades to be plotted on the vertical axis; default is 5
 #
 # In all cases, the plot file is placed next to the simulation output file(s) being handled. The filename starts
@@ -31,16 +32,16 @@
 
 def do( simDirPath : (str,"SKIRT simulation output directory"),
         prefix : (str,"SKIRT simulation prefix") = "",
-        wmin : (float,"smallest wavelength on the horizontal axis, in micron") = 0.1,
-        wmax : (float,"largest wavelength on the horizontal axis, in micron") = 1000.,
+        wmin : (float,"smallest wavelength on the horizontal axis") = 0.1,
+        wmax : (float,"largest wavelength on the horizontal axis") = 1000.,
+        unit: (str,"unit of the wavelength limits (any spectral unit)") = "micron",
         dex : (float,"number of decades to be plotted on the vertical axis") = 5,
         ) -> "plot the luminosity of and packets launched by one or more SKIRT simulations":
 
-    import astropy.units as u
     import pts.simulation as sm
     import pts.visual as vis
 
     for sim in sm.createSimulations(simDirPath, prefix if len(prefix)>0 else None):
-        vis.plotSources(sim, minWavelength=wmin * u.micron, maxWavelength=wmax * u.micron, decades=dex)
+        vis.plotSources(sim, minWavelength=wmin*sm.unit(unit), maxWavelength=wmax*sm.unit(unit), decades=dex)
 
 # ----------------------------------------------------------------------

--- a/visual/do/plot_spectral_resolution.py
+++ b/visual/do/plot_spectral_resolution.py
@@ -12,8 +12,9 @@
 #
 # Provide the name or (relative or absolute) file path of a SKIRT stored table file or a SKIRT output file
 # as the single required argument, and use optional arguments to further configure the plot:
-#  - \em wmin (float): smallest wavelength on the horizontal axis, in micron; default is 0.1 micron
-#  - \em wmax (float): largest wavelength on the horizontal axis, in micron; default is 1000 micron
+#  - \em wmin (float): smallest wavelength on the horizontal axis; default is 0.1
+#  - \em wmax (float): largest wavelength on the horizontal axis; default is 1000
+#  - \em unit (string): unit of the wavelength limits (any spectral unit); default is micron
 #  - \em dex (float): if specified, the number of decades to be plotted on the vertical axis; default is 3
 #  - \em title (string): the title used in the plot legend; default is the name of the input file
 #
@@ -24,16 +25,17 @@
 # -----------------------------------------------------------------
 
 def do( filepath : (str,"name or path of SKIRT stored table or text column file"),
-        wmin : (float,"smallest wavelength on the horizontal axis, in micron") = 0.1,
-        wmax : (float,"largest wavelength on the horizontal axis, in micron") = 1000.,
+        wmin : (float,"smallest wavelength on the horizontal axis") = 0.1,
+        wmax : (float,"largest wavelength on the horizontal axis") = 1000.,
+        unit: (str,"unit of the wavelength limits (any spectral unit)") = "micron",
         dex : (float,"number of decades to be plotted on the vertical axis") = 3,
         title : (str,"title used in plot legend") = "",
         ) -> "plot the spectral resolution of a wavelength axis":
 
-    import astropy.units as u
+    import pts.simulation as sm
     import pts.visual as vis
 
-    vis.plotSpectralResolution(inFilePath=filepath, minWavelength=wmin * u.micron, maxWavelength=wmax * u.micron,
+    vis.plotSpectralResolution(inFilePath=filepath, minWavelength=wmin*sm.unit(unit), maxWavelength=wmax*sm.unit(unit),
                                decades=dex, title=title)
 
 # -----------------------------------------------------------------


### PR DESCRIPTION
**Description**
The `pts` command line scripts
 - `plot_seds`
 - `plot_sources`
 - `plot_spectral_resolution`

now allow specifying the units of the wavelength range as a separate command line argument, including any spectral flavor units supported by SKIRT. For example, one can enter:

`pts plot_seds . --unit keV --wmin 0.1 --wmax 100`

to specify a spectral energy range from 0.1 to 100 keV.

**Motivation**
This feature is especially relevant when plotting the results of X-ray simulations.

