### PR TITLE
Correctly plot broadbands when specifying multiple name segments

### DIFF
--- a/band/broadband.py
+++ b/band/broadband.py
@@ -200,7 +200,7 @@ class BroadBand:
         specsegments = nameSegments.upper().replace("_"," ").replace(","," ").split()
         for bandpath in cls._bandpaths:
             bandsegments = bandpath.stem[:-10].upper().replace("_"," ").split()
-            if all([ (specsegment in bandsegments) for specsegment in specsegments ]):
+            if any([ (specsegment in bandsegments) for specsegment in specsegments ]):
                 result.append(BroadBand(bandpath))
 
         # remove bands outside of the specified wavelength range


### PR DESCRIPTION
**Motivation**
As reported in this [issue](https://github.com/SKIRT/SKIRT9/issues/222), the command `pts plot_bands --names="..."` fails when specifying multiple band name segments.

**Description**
This behavior was introduced by a bug in pull request #42 and is fixed by the current pull request.
