### PR TITLE
The plot_opacity script picks the middle frame as a workaround

### DIFF
--- a/visual/do/plot_opacity.py
+++ b/visual/do/plot_opacity.py
@@ -13,6 +13,11 @@
 # is an opacity \f$k=\kappa\rho=n\varsigma\f$; for projections, the plotted quantity is an optical depth \f$\tau\f$.
 # If the simulation does not include any supported probes, the script does nothing.
 #
+# \note If the wavelength grid configured for the opacity probe specifies more than a single wavelength, the probe's
+# output is a data cube with a frame for each of these wavelengths. In that case, this script selects the middle frame
+# from the data cube, i.e. the frame with index int("nr of frames" / 2).
+# This is a work-around to make plot_opacity work now that the opacity probe can output multiple frames.
+#
 # If the output for a given medium component or medium type (dust, gas, or electrons) includes two or three files
 # with names that differ only by orientation labels ("_xy", "_xz", and/or "_yz"), the density maps for these
 # files are included in a single plot and share the same scale.

--- a/visual/plotscalarcuts.py
+++ b/visual/plotscalarcuts.py
@@ -27,6 +27,10 @@ import pts.utils as ut
 # with an associated probe form that produces a planar cut (DefaultCutsForm, PlanarCutsForm) or planar
 # projection (ParallelProjectionForm, AllSkyProjectionForm). If this is not the case, the function does nothing.
 #
+# \note If the probe output in the encountered FITS file(s) is a data cube instead of a single data frame, this
+# function selects the middle frame from the data cube, i.e. the frame with index int("nr of frames" / 2).
+# This is a work-around to make plot_opacity work now that the opacity probe outputs multiple frames.
+#
 # For \em decades=0, the color scale is linear. For \em decades>0, the color scale is logarithmic with the given
 # dynamic range in dex.
 #

--- a/visual/plotscalarcuts.py
+++ b/visual/plotscalarcuts.py
@@ -79,6 +79,11 @@ def plotScalarCuts(simulation, probeTypes, decades=5, *,
         frames = [ sm.loadFits(path) for path in pathgroup ]
         grids = [ sm.getFitsAxes(path) for path in pathgroup ]
 
+        # if the frames happen to be cubes, select the middle frame
+        # (this is a hack to make plot_opacity work now that the opacity probe outputs multiple frames)
+        frames = [ frame if len(frame.shape) == 2 else frame[:,:,frame.shape[2]//2] for frame in frames ]
+        grids = [ grid if len(grid) == 2 else grid[0:2] for grid in grids ]
+
         # determine the range of values to display and clip the data arrays
         vmax = max([ frame.max() for frame in frames ])
         vmin = vmax - vmax  # to retain units


### PR DESCRIPTION
**Motivation**
Since yesterday's update, SKIRT's `OpacityProbe` outputs multiple frames, i.e. one for each wavelength in the configured wavelength grid. Even if the wavelength grid contains just a single wavelength, the probe outputs a data cube (with a single frame) causing the previous version of the `pts plot_opacity` script to fail.

**Description**
As a work-around, the `pts plot_opacity` script now selects the middle frame from the data cube, i.e. the frame with index int("nr of frames" / 2). If there is only a single frame, the behavior is as before. If there are multiple frames, the user unfortunately has no choice of which frame to plot.
